### PR TITLE
Respond with multiple `lsp.TextEdit`s instead of one replacing the entire input.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[src/**.ts]
+indent_style = space
+indent_size = 2

--- a/src/stylua/connection.ts
+++ b/src/stylua/connection.ts
@@ -1,5 +1,5 @@
 import * as lsp from 'vscode-languageserver/node';
-import {textDocuments} from './textDocuments.js';
+import { textDocuments } from './textDocuments.js';
 import cp from 'child_process';
 import which from 'which';
 import { isExecutable, isLua } from '../common.js';
@@ -50,7 +50,7 @@ export async function createConnection(): Promise<lsp.Connection> {
     if (bin && !STATE.bin) {
       STATE.bin = bin;
     }
-  }).catch(() => {});
+  }).catch(() => { });
 
   const connection = lsp.createConnection(process.stdin, process.stdout);
   textDocuments.listen(connection);
@@ -62,12 +62,12 @@ export async function createConnection(): Promise<lsp.Connection> {
       STATE.cwd = filePath;
     }
     return {
-			capabilities: {
-				textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
-				documentFormattingProvider: true,
-				documentRangeFormattingProvider: true,
-			},
-		}
+      capabilities: {
+        textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
+        documentFormattingProvider: true,
+        documentRangeFormattingProvider: true,
+      },
+    }
   })
 
   connection.onDocumentFormatting(async (params) => {
@@ -97,7 +97,7 @@ export async function createConnection(): Promise<lsp.Connection> {
       connection.console.error(`stylua format error: ${e}`)
       return null
     }
-	})
+  })
 
   connection.onDocumentRangeFormatting(async (params) => {
     if (!STATE.bin) {
@@ -130,7 +130,7 @@ export async function createConnection(): Promise<lsp.Connection> {
       connection.console.error(`stylua format error: ${e}`)
       return null
     }
-	})
+  })
 
   connection.onDidChangeConfiguration(async change => {
     const settings = change.settings;

--- a/src/stylua/connection.ts
+++ b/src/stylua/connection.ts
@@ -4,9 +4,48 @@ import cp from 'child_process';
 import which from 'which';
 import { isExecutable, isLua } from '../common.js';
 
+interface StyluaOutput {
+  file: "stdin",
+  mismatches: Diff[],
+}
+
+interface Diff {
+  expected: string,
+  expected_end_line: number,
+  expected_start_line: number,
+  original: string,
+  original_end_line: number,
+  original_start_line: number,
+}
+
+function diff_to_text_edit(diff: Diff): lsp.TextEdit {
+  if (diff.original == '') {
+    return lsp.TextEdit.insert(lsp.Position.create(diff.expected_start_line, 0), diff.expected)
+  }
+
+  const start = lsp.Position.create(diff.original_start_line, 0)
+  // NOTE: `lsp.Range` end is exclusive, `original_end_line` inclusive
+  const endExclusive = lsp.Position.create(diff.original_end_line + 1, 0)
+  const range = lsp.Range.create(start, endExclusive)
+
+  if (diff.expected == '') {
+    return lsp.TextEdit.del(range)
+  } else {
+    return lsp.TextEdit.replace(
+      range,
+      diff.expected
+    )
+  }
+}
+
+function outputToTextEdits(styluaOutput: string): lsp.TextEdit[] {
+  let out: StyluaOutput = JSON.parse(styluaOutput);
+  return out.mismatches.map(diff_to_text_edit)
+}
+
 async function styluaFormat(cwd: string, bin: string, filepath: string, content: string, rangeStart?: number, rangeEnd?: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    const args = ['--search-parent-directories', '--stdin-filepath', filepath];
+    const args = ['--search-parent-directories', '--check', '--output-format=JSON', '--stdin-filepath', filepath];
     if (rangeStart != null && rangeEnd != null) {
       args.push('--range-start', rangeStart.toString(), '--range-end', rangeEnd.toString());
     }
@@ -27,10 +66,15 @@ async function styluaFormat(cwd: string, bin: string, filepath: string, content:
     });
 
     child.on('exit', (code) => {
-      if (code === 0) {
-        resolve(output);
-      } else {
-        reject(`stylua exited with code ${code}`);
+      switch (code) {
+        case 0:
+          resolve(JSON.stringify([]))
+          break
+        case 1:
+          resolve(output)
+          break
+        default:
+          reject(`stylua exited with code ${code}`);
       }
     });
 
@@ -85,14 +129,10 @@ export async function createConnection(): Promise<lsp.Connection> {
 
     const originalText = textDocument.getText()
 
-    const start = { line: 0, character: 0 }
-    const end = textDocument.positionAt(originalText.length)
-    const range = lsp.Range.create(start, end)
-
     try {
-      const formattedText = await styluaFormat(STATE.cwd, STATE.bin, textDocument.uri, originalText)
+      const output = await styluaFormat(STATE.cwd, STATE.bin, textDocument.uri, originalText)
 
-      return [lsp.TextEdit.replace(range, formattedText)]
+      return outputToTextEdits(output)
     } catch (e) {
       connection.console.error(`stylua format error: ${e}`)
       return null
@@ -118,14 +158,8 @@ export async function createConnection(): Promise<lsp.Connection> {
     const rangeEnd = textDocument.offsetAt(params.range.end)
 
     try {
-      const formattedText = await styluaFormat(STATE.cwd, STATE.bin, textDocument.uri, originalText, rangeStart, rangeEnd)
-
-      const formattedTextRanged = formattedText.slice(
-        rangeStart,
-        rangeEnd + formattedText.length - originalText.length,
-      )
-
-      return [lsp.TextEdit.replace(params.range, formattedTextRanged)]
+      const output = await styluaFormat(STATE.cwd, STATE.bin, textDocument.uri, originalText, rangeStart, rangeEnd)
+      return outputToTextEdits(output)
     } catch (e) {
       connection.console.error(`stylua format error: ${e}`)
       return null


### PR DESCRIPTION
**Problem**: The response to the format request is a single text edit
replacing all existing code.
**Solution**: Run stylua with the `--check` and `--output-format=JSON` flags
to obtain a list of mismatches between the unformatted and formatted
code. Then transform each mismatch to a `lsp.TextEdit`.

This PR also adds a `.editorconfig` file.

Closes #1.